### PR TITLE
add cmake support and fix compile errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.7)
+project(udp2raw_tunnel)
+
+set(CMAKE_CXX_STANDARD 11)
+
+set(SOURCE_FILES
+        lib/aes.c
+        lib/md5.c
+        common.cpp
+        encrypt.cpp
+        log.cpp
+        main.cpp
+        network.cpp
+        )
+set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wno-unused-variable -Wno-unused-parameter -static")
+set(CMAKE_LINK_LIBRARY_FLAG "-lrt")
+add_executable(udp2raw_tunnel ${SOURCE_FILES})

--- a/encrypt.cpp
+++ b/encrypt.cpp
@@ -1,11 +1,13 @@
-#include <lib/aes.h>
-#include <lib/md5.h>
+extern "C"{
+    #include "lib/aes.h"
+    #include "lib/md5.h"
+}
 #include <string.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <encrypt.h>
-#include <common.h>
+#include "encrypt.h"
+#include "common.h"
 #include "log.h"
 
 //static uint64_t seq=1;

--- a/log.cpp
+++ b/log.cpp
@@ -1,4 +1,4 @@
-#include <log.h>
+#include "log.h"
 
 int log_level=log_info;
 

--- a/log.h
+++ b/log.h
@@ -44,7 +44,7 @@
 
 #include <sys/timerfd.h>
 #include <set>
-#include <encrypt.h>
+#include "encrypt.h"
 #include <inttypes.h>
 
 #include <sys/ioctl.h>

--- a/main.cpp
+++ b/main.cpp
@@ -1,7 +1,9 @@
 #include "common.h"
 #include "network.h"
 #include "log.h"
-#include "lib/md5.h"
+extern "C" {
+	#include "lib/md5.h"
+}
 
 char local_address[100]="0.0.0.0", remote_address[100]="255.255.255.255",source_address[100]="0.0.0.0";
 u32_t local_address_uint32,remote_address_uint32,source_address_uint32;


### PR DESCRIPTION
Several compilation and linking error occurred due to small noncompliance to the standard. This PR fixed the problem and added CMake support (to support Jetbrains CLion). 