### PR TITLE
security: discourage users from running udp2raw as root

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,32 @@ Assume your UDP is blocked or being QOS-ed or just poorly supported. Assume your
 
 Now,an encrypted raw tunnel has been established between client and server through TCP port 4096. Connecting to UDP port 3333 at the client side is equivalent to connecting to port 7777 at the server side. No UDP traffic will be exposed.
 
+### Security (IMPORTANT)
+
+Running the whole process with root previlege may bring security exploits. With root previleges, any bug in this program could endanger the entire system. This is especially true for bugs that may bring possibilities to execute any arbitary code within the program. For this reason, it is always recommended that the process should not be running as root.
+
+Instead, under Linux, one should use [Capabilities](http://man7.org/linux/man-pages/man7/capabilities.7.html), or more specifically, `CAP_NET_RAW` and `CAP_NET_ADMIN` for this program, and then run the process under some normal users or even with `nobody`. You will not be able to use the `-a` option under such circumstance, therefore the `iptables` rules (as is shown by running the program) will need to be inserted manually. This ensures that no unnecessary permissions are granted to the program and decreases security risk.
+
+For example, to run the above example without root, first you need to set capabilities to the binary (the following shell commands should be all executed under a non-root user, except the `sudo` lines)
+
+```bash
+sudo setcap cap_net_raw,cap_net_admin+ep udp2raw_amd64
+```
+
+Afterwards
+
+```bash
+# Server side:
+sudo iptables -I INPUT -p tcp --dport 4096 -j DROP
+./udp2raw_amd64 -s -l0.0.0.0:4096 -r 127.0.0.1:7777  -k "passwd" --raw-mode faketcp
+
+# Client side
+sudo iptables -I INPUT -s 44.55.66.77:4096 -p tcp --sport 4096 -j DROP
+./udp2raw_amd64 -c -l0.0.0.0:3333  -r44.55.66.77:4096 -k "passwd" --raw-mode faketcp
+```
+
+You have now been warned of the security risks to run this program as root. If you insist on doing so, please always notice that you should take your own risk on such operations, since there is no guarantee that this program has no security exploits. After all, this is a personal project, without any dedicated security team.
+
 ### Note
 to run on Android, see [Android_Guide](/doc/android_guide.md)
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ sudo iptables -I INPUT -p tcp --dport 4096 -j DROP
 ./udp2raw_amd64 -s -l0.0.0.0:4096 -r 127.0.0.1:7777  -k "passwd" --raw-mode faketcp
 
 # Client side
-sudo iptables -I INPUT -s 44.55.66.77:4096 -p tcp --sport 4096 -j DROP
+sudo iptables -I INPUT -s 44.55.66.77 -p tcp --sport 4096 -j DROP
 ./udp2raw_amd64 -c -l0.0.0.0:3333  -r44.55.66.77:4096 -k "passwd" --raw-mode faketcp
 ```
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ You have now been warned of the security risks to run this program as root. If y
 ### Note
 to run on Android, see [Android_Guide](/doc/android_guide.md)
 
+For `systemd` users, you can use the configuration as is shown in [this example](/doc/systemd_example.md) for better security and convenience.
+
 # Advanced Topic
 ### Usage
 ```

--- a/doc/finalspeed_step_by_step.md
+++ b/doc/finalspeed_step_by_step.md
@@ -28,6 +28,11 @@ https://github.com/wangyu-/udp2raw-tunnel/releases
 
 在服务器端安装好finalspeed服务端，在本地windows安装好finalspeed的客户端。服务端我以前是用91yun的一键安装脚本安装的，没装过的可以去网上搜一键安装脚本。
 
+
+### 安全
+
+使用 ROOT 运行 `udp2raw` 可能带来安全隐患，因此，以下 `udp2raw` 命令将全部以非 ROOT 用户执行。请先阅读 [这个文档](/README.md#security-important) 以确保以下指令能够正确执行。
+
 ### 运行
 1.先在服务器主机运行如下命令，确定finalspeed服务端已经正常启动了。
 
@@ -40,13 +45,15 @@ netstat -nlp|grep java
 
 2.在服务器启动udp2raw server
 ```
- ./udp2raw_amd64 -s -l0.0.0.0:8855 -r 127.0.0.1:150  -a -k "passwd" --raw-mode faketcp
+sudo iptables -I INPUT -p tcp --dport 8855 -j DROP
+ ./udp2raw_amd64 -s -l0.0.0.0:8855 -r 127.0.0.1:150 -k "passwd" --raw-mode faketcp
 ```
 ![image](finalspeed_step_by_step/Capture2.PNG)
 
 3.在本地的虚拟机上启动udp2raw client  ,假设服务器ip是45.66.77.88
 ```
-./udp2raw_amd64 -c -r45.66.77.88:8855 -l0.0.0.0:150 --raw-mode faketcp -a -k"passwd"
+sudo iptables -I INPUT -s 45.66.77.88 -p tcp --sport 8855 -j DROP
+./udp2raw_amd64 -c -r45.66.77.88:8855 -l0.0.0.0:150 --raw-mode faketcp -k"passwd"
 ```
 如果一切正常，client端会显示client_ready:
 

--- a/doc/kcptun_step_by_step.md
+++ b/doc/kcptun_step_by_step.md
@@ -18,16 +18,22 @@ https://github.com/wangyu-/udp2raw-tunnel/releases
 解压好后，如图：
 ![image](kcptun_step_by_step/Capture0.PNG)
 
+### 安全
+
+使用 ROOT 运行 `udp2raw` 可能带来安全隐患，因此，以下 `udp2raw` 命令将全部以非 ROOT 用户执行。请先阅读 [这个文档](/README.md#security-important) 以确保以下指令能够正确执行。
+
 ### 运行
 1.在远程服务器运行 udp2raw_amd64 server模式：
-```
-./udp2raw_amd64 -s -l0.0.0.0:8855 -r 127.0.0.1:4000 -k "passwd" --raw-mode faketcp -a
+```bash
+sudo iptables -I INPUT -p tcp --dport 8855 -j DROP
+./udp2raw_amd64 -s -l0.0.0.0:8855 -r 127.0.0.1:4000 -k "passwd" --raw-mode faketcp
 ```
 ![image](kcptun_step_by_step/Capture.PNG)
 
 2.在本地运行udp2raw_amd64 client模式，假设server ip是45.66.77.88：
-```
-./udp2raw_amd64 -c -r45.66.77.88:8855 -l0.0.0.0:4000 --raw-mode faketcp -a -k"passwd"
+```bash
+sudo iptables -I INPUT -p tcp -s 45.66.77.88 --sport 8855 -j DROP
+./udp2raw_amd64 -c -r45.66.77.88:8855 -l0.0.0.0:4000 --raw-mode faketcp -k"passwd"
 ```
 如果一切正常client端输出如下，显示client_ready：
 ![image](kcptun_step_by_step/Capture2.PNG)

--- a/doc/openvpn_guide.md
+++ b/doc/openvpn_guide.md
@@ -4,7 +4,7 @@
 ![image4](/images/image4.PNG)
 # udp2raw command
 
-It is always recommended to run `udp2raw` under a NON-ROOT user. For the following commands to work, please read [README](/README.md) first.
+It is always recommended to run `udp2raw` under a NON-ROOT user. For the following commands to work, please read [this document](/README.md#security-important) first.
 
 #### run at server side
 ```bash

--- a/doc/openvpn_guide.md
+++ b/doc/openvpn_guide.md
@@ -3,14 +3,19 @@
 
 ![image4](/images/image4.PNG)
 # udp2raw command
+
+It is always recommended to run `udp2raw` under a NON-ROOT user. For the following commands to work, please read [README](/README.md) first.
+
 #### run at server side
-```
-./udp2raw_amd64 -s -l0.0.0.0:8855 -r 127.0.0.1:7777 -k "passwd" --raw-mode faketcp -a
+```bash
+sudo iptables -I INPUT -p tcp --dport 8855 -j DROP
+./udp2raw_amd64 -s -l0.0.0.0:8855 -r 127.0.0.1:7777 -k "passwd" --raw-mode faketcp
 ```
 #### run at client side
 assume server ip is 45.66.77.88
 ```
-./udp2raw_amd64 -s -l0.0.0.0:3333 -r 45.66.77.88:8855 -k "passwd" --raw-mode faketcp -a
+sudo iptables -I INPUT -s 45.66.77.88 -p tcp --sport 8855 -j DROP
+./udp2raw_amd64 -s -l0.0.0.0:3333 -r 45.66.77.88:8855 -k "passwd" --raw-mode faketcp
 ```
 
 

--- a/doc/systemd_example.md
+++ b/doc/systemd_example.md
@@ -1,4 +1,6 @@
 # systemd service file
+
+### Client
 ```
 [Unit]
 Description=UDP2RAW service
@@ -20,7 +22,29 @@ StartLimitBurst=10
 WantedBy=multi-user.target
 ```
 
-Please replace `SERVER_IP`, `SERVER_PORT` and `LOCAL_PORT` with your own parameters and replace the pathes to `iptables` and `udp2raw` according to your own system configuration.
+### Server
+```
+[Unit]
+Description=UDP2RAW service
+After=network-online.service
+
+[Service]
+User=nobody
+Type=simple
+PermissionsStartOnly=true
+CapabilityBoundingSet=CAP_NET_RAW CAP_NET_ADMIN
+ExecStartPre=/sbin/iptables -I INPUT -p tcp --dport SERVER_PORT -j DROP
+ExecStart=/usr/bin/udp2raw -s -l0.0.0.0:SERVER_PORT -r127.0.0.1:REMOTE_PORT -k PASSWORD --raw-mode faketcp
+ExecStopPost=/sbin/iptables -D INPUT -p tcp --dport SERVER_PORT -j DROP
+Restart=always
+RestartSec=30
+StartLimitBurst=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Please replace `SERVER_IP`, `SERVER_PORT`, `REMOTE_PORT` and `LOCAL_PORT` with your own parameters and replace the pathes to `iptables` and `udp2raw` according to your own system configuration.
 
 The above unit will only execute the `iptables` commands as root, and will execute the main `udp2raw` command as `nobody`, with `CapabilityBoundingSet` that grants necessary permissions.
 

--- a/doc/systemd_example.md
+++ b/doc/systemd_example.md
@@ -1,0 +1,27 @@
+# systemd service file
+```
+[Unit]
+Description=UDP2RAW service
+After=network-online.service
+
+[Service]
+User=nobody
+Type=simple
+PermissionsStartOnly=true
+CapabilityBoundingSet=CAP_NET_RAW CAP_NET_ADMIN
+ExecStartPre=/sbin/iptables -I INPUT -s SERVER_IP -p tcp --sport SERVER_PORT -j DROP
+ExecStart=/usr/bin/udp2raw -c -l127.0.0.1:LOCAL_PORT -rSERVER_IP:SERVER_PORT -k PASSWORD --raw-mode faketcp
+ExecStopPost=/sbin/iptables -D INPUT -s SERVER_IP -p tcp --sport SERVER_PORT -j DROP
+Restart=always
+RestartSec=30
+StartLimitBurst=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Please replace `SERVER_IP`, `SERVER_PORT` and `LOCAL_PORT` with your own parameters and replace the pathes to `iptables` and `udp2raw` according to your own system configuration.
+
+The above unit will only execute the `iptables` commands as root, and will execute the main `udp2raw` command as `nobody`, with `CapabilityBoundingSet` that grants necessary permissions.
+
+You may also need to run `setcap cap_net_raw,cap_net_admin+ep udp2raw` on the `udp2raw` binary


### PR DESCRIPTION
Running programs like `udp2raw` under `root` is not a good practice. Any exploit in the program is possible to endanger the entire system if running as root, especially when `udp2raw` is even invoking shell commands when executing. This is more than dangerous since `udp2raw` is purely a personal project and do not have any dedicated security team for CVEs.

Fortunately, Linux provides an approach to use raw sockets without root privilege: Capabilities. Granting `CAP_NET_RAW` and `CAP_NET_ADMIN` is enough for `udp2raw` to execute happily even under `nobody`. The only tradeoff is that `udp2raw` would not be able to insert `iptables` rules without root. Therefore, user need to insert them manually. This is a much small tradeoff compared with the security risks -- always remember what we are using `udp2raw` for.

This PR adds warnings and guides about running `udp2raw` without root privilege. It is hopeful that users will read them before actually beginning using `udp2raw`. A convenient `systemd` unit is also provided for non-root uses.

BTW, if you use [this library](http://wiki.tldp.org/iptc%20library%20HOWTO) instead of `iptables` to insert the netfilter rules, users will not need to invoke `iptables` manually. This can be done also with `capabilities` if so.