### PR TITLE
ARM toolchain statically linked binds /bin/sh

### DIFF
--- a/common.cpp
+++ b/common.cpp
@@ -306,7 +306,7 @@ void myexit(int a)
    	printf("%s\n",RESET);
     if(keep_thread_running)
     {
-		if(pthread_cancel(keep_thread))
+		if(pthread_kill(keep_thread,SIGUSR1))
 		{
 			mylog(log_warn,"pthread_cancel failed\n");
 		}

--- a/main.cpp
+++ b/main.cpp
@@ -1192,7 +1192,7 @@ int client_event_loop()
 	local_me.sin_addr.s_addr = local_ip_uint32;
 
 
-	if (bind(udp_fd, (struct sockaddr*) &local_me, slen) == -1) {
+	if (::bind(udp_fd, (struct sockaddr*) &local_me, slen) == -1) {
 		mylog(log_fatal,"socket bind error\n");
 		//perror("socket bind error");
 		myexit(1);
@@ -1436,7 +1436,7 @@ int server_event_loop()
      temp_bind_addr.sin_port = htons(local_port);
      temp_bind_addr.sin_addr.s_addr = local_ip_uint32;
 
-     if (bind(bind_fd, (struct sockaddr*)&temp_bind_addr, sizeof(temp_bind_addr)) !=0)
+     if (::bind(bind_fd, (struct sockaddr*)&temp_bind_addr, sizeof(temp_bind_addr)) !=0)
      {
     	 mylog(log_fatal,"bind fail\n");
     	 myexit(-1);

--- a/network.cpp
+++ b/network.cpp
@@ -1887,7 +1887,7 @@ int try_to_list_and_bind(int &fd,u32_t local_ip_uint32,int port)  //try to bind 
      temp_bind_addr.sin_port = htons(port);
      temp_bind_addr.sin_addr.s_addr = local_ip_uint32;
 
-     if (bind(fd, (struct sockaddr*)&temp_bind_addr, sizeof(temp_bind_addr)) !=0)
+     if (::bind(fd, (struct sockaddr*)&temp_bind_addr, sizeof(temp_bind_addr)) !=0)
      {
     	 mylog(log_debug,"bind fail\n");
     	 return -1;


### PR DESCRIPTION
/bin/sh is present in Android, so you have to handle iptables manually as described in
https://github.com/wangyu-/udp2raw-tunnel/blob/master/doc/android_guide.md

By applying this patch I've been able to compile and run natively in
android using termux g++ using dynamic linking, so I have -a flag
working on Android