### PR TITLE
Creat a GUI app for android

### DIFF
--- a/doc/build_guide.md
+++ b/doc/build_guide.md
@@ -8,7 +8,7 @@ the guide on how to build udp2raw
 such as PC,raspberry pi
 
 ##### install git
-run on debian/ubuntun：
+run on debian/ubuntu:
 ```
 sudo apt-get install git
 ```
@@ -18,7 +18,7 @@ sudo yum install git
 ```
 ##### clone git code
 
-run in any dir：
+run in any dir:
 
 ```
 git clone https://github.com/wangyu-/udp2raw-tunnel.git
@@ -26,7 +26,7 @@ cd udp2raw-tunnel
 ```
 
 ##### install compile tool
-run on debian/ubuntun：
+run on debian/ubuntu:
 ```
 sudo apt-get install build-essential
 ```
@@ -42,7 +42,7 @@ run 'make'，compilation done. the udp2raw file is the just compiled binary
 such as openwrt router,run following instructions on your PC
 
 ##### install git
-run on debian/ubuntun：
+run on debian/ubuntu:
 ```
 sudo apt-get install git
 ```


### PR DESCRIPTION
This is just a suggestion, if the main Devs of this project don't want to do this, hopefully someone else does?
I suggest an android app with a GUI (same goes for Desktop OSs but at least those have the CLI but android lacks even that) that can enable and disable a certain config of udp2raw.
A better version of this would be to add udp2raw to an existing open source VPN client like WireGuard and make something like WireGuard2raw which would be a WireGuard client that natively supports udp2raw.