### PR TITLE
Add --wireguard mode

### DIFF
--- a/common.h
+++ b/common.h
@@ -163,6 +163,8 @@ extern int force_socket_buf;
 
 extern int g_fix_gro;
 
+extern int g_randomize_local_addr;
+
 /*
 struct ip_port_t
 {

--- a/misc.cpp
+++ b/misc.cpp
@@ -296,6 +296,9 @@ void process_arg(int argc, char *argv[])  // process all options
             {"no-pcap-mutex", no_argument, 0, 1},
 #endif
             {"fix-gro", no_argument, 0, 1},
+            {"do-fragment", no_argument, 0, 1},
+            {"rand-addr", no_argument, 0, 1},
+            {"wireguard", no_argument, 0, 1},
             {NULL, 0, 0, 0}};
 
     process_log_level(argc, argv);
@@ -677,6 +680,16 @@ void process_arg(int argc, char *argv[])  // process all options
                 } else if (strcmp(long_options[option_index].name, "fix-gro") == 0) {
                     mylog(log_info, "--fix-gro enabled\n");
                     g_fix_gro = 1;
+                } else if (strcmp(long_options[option_index].name, "do-fragment") == 0) {
+                    mylog(log_info, "--do-fragment enabled\n");
+                    g_should_fragment = 1;
+                } else if (strcmp(long_options[option_index].name, "rand-addr") == 0) {
+                    mylog(log_info, "--rand-addr enabled\n");
+                    g_randomize_local_addr = 1;
+                } else if (strcmp(long_options[option_index].name, "wireguard") == 0) {
+                    mylog(log_info, "--wireguard mode enabled, turning on --do-fragment and --rand-addr\n");
+                    g_should_fragment = 1;
+                    g_randomize_local_addr = 1;
                 } else {
                     mylog(log_warn, "ignored unknown long option ,option_index:%d code:<%x>\n", option_index, optopt);
                 }

--- a/network.cpp
+++ b/network.cpp
@@ -1159,6 +1159,7 @@ printf("pcap send!\n");*/
 }
 #endif
 
+int g_should_fragment = 0;
 int send_raw_ip(raw_info_t &raw_info, const char *payload, int payloadlen) {
     const packet_info_t &send_info = raw_info.send_info;
     const packet_info_t &recv_info = raw_info.recv_info;
@@ -1188,8 +1189,11 @@ int send_raw_ip(raw_info_t &raw_info, const char *payload, int payloadlen) {
             // iph->id = 0; //Id of this packet  ,kernel will auto fill this if id is zero  ,or really?????// todo //seems like there is a problem
         }
 
-        iph->frag_off = htons(0x4000);  // DF set,others are zero
-        // iph->frag_off = htons(0x0000); //DF set,others are zero
+        if (g_should_fragment) {
+            iph->frag_off = htons(0x0000);  //DF cleared,others are zero
+        } else {
+            iph->frag_off = htons(0x4000);  // DF set,others are zero
+        }
         iph->ttl = (unsigned char)ttl_value;
         iph->protocol = send_info.protocol;
         iph->check = 0;                        // Set to 0 before calculating checksum

--- a/network.h
+++ b/network.h
@@ -56,6 +56,8 @@ struct icmphdr {
 };
 #endif
 
+extern int g_should_fragment;
+
 struct my_iphdr {
 #ifdef UDP2RAW_LITTLE_ENDIAN
     unsigned char ihl : 4;


### PR DESCRIPTION
Added an option `--wireguard` triggering two small changes to address wireguard quirks:

- Clear DF bit: wireguard MTU is quite small already and adding udp2raw on top breaks a lot of stuff. Allow fragmenting udp2raw's own raw packets in `--wireguard`. Can be enabled individually with `--do-fragment`.
- Wireguard allows endpoint IP changes but rejects *port-only* endpoint changes. By default, `udp2raw -s` connects from a different port on 127.0.0.1 for each client, which will start getting rejected by wireguard from the 2nd attempt. As a workaround, when `--wireguard` is enabled and `udp2raw` tries to connect to a link-local address, the patch generates a different link-local source IP for each connection. Can be enabled individually with `--rand-addr`.
