### PR TITLE
Fix compile errors on FreeBSD/pfSense/OPNsense

### DIFF
--- a/makefile
+++ b/makefile
@@ -103,7 +103,7 @@ linux:git_version
 	${cc_local}   -o ${NAME}_$@          -I. ${SOURCES} ${PCAP} ${FLAGS} -lrt -ggdb -static -O2 ${MP}
 
 freebsd:git_version
-	${cc_local}   -o ${NAME}_$@        -I. ${SOURCES} ${PCAP} ${FLAGS} -lrt -ggdb -static -O2 ${MP}
+	${cc_local}   -o ${NAME}_$@        -I. ${SOURCES} ${PCAP} ${FLAGS} -lrt -ggdb -static -libverbs -O2 ${MP}
 
 mac:git_version
 	${cc_local}   -o ${NAME}_$@        -I. ${SOURCES} ${PCAP} ${FLAGS} -ggdb -O2 ${MP}


### PR DESCRIPTION
Fix the compilation error below

```sh
root@:~/udp2raw # make freebsd
echo "const char *gitversion = \"\";" > git_version.h
g++   -o udp2raw_freebsd        -I. main.cpp lib/md5.cpp lib/pbkdf2-sha1.cpp lib/pbkdf2-sha256.cpp encrypt.cpp log.cpp network.cpp common.cpp  connection.cpp misc.cpp fd_manager.cpp client.cpp server.cpp -lpthread lib/aes_faster_c/aes.cpp lib/aes_faster_c/wrapper.cpp my_ev.cpp -isystem libev "-lpcap" -std=c++11   -Wall -Wextra -Wno-unused-variable -Wno-unused-parameter -Wno-missing-field-initializers  -lrt -ggdb -static -O2 "-DUDP2RAW_MP"
/usr/local/bin/ld: /usr/lib/libpcap.a(pcap-rdmasniff.o): in function `rdmasniff_create':
/usr/src/contrib/libpcap/pcap-rdmasniff.c:370: undefined reference to `ibv_get_device_list'
/usr/local/bin/ld: /usr/src/contrib/libpcap/pcap-rdmasniff.c:405: undefined reference to `ibv_free_device_list'
/usr/local/bin/ld: /usr/lib/libpcap.a(pcap-rdmasniff.o): in function `rdmasniff_activate':
/usr/src/contrib/libpcap/pcap-rdmasniff.c:198: undefined reference to `ibv_open_device'
/usr/local/bin/ld: /usr/src/contrib/libpcap/pcap-rdmasniff.c:205: undefined reference to `ibv_alloc_pd'
/usr/local/bin/ld: /usr/src/contrib/libpcap/pcap-rdmasniff.c:212: undefined reference to `ibv_create_comp_channel'
/usr/local/bin/ld: /usr/src/contrib/libpcap/pcap-rdmasniff.c:219: undefined reference to `ibv_create_cq'
/usr/local/bin/ld: /usr/src/contrib/libpcap/pcap-rdmasniff.c:234: undefined reference to `ibv_create_qp'
/usr/local/bin/ld: /usr/src/contrib/libpcap/pcap-rdmasniff.c:244: undefined reference to `ibv_modify_qp'
/usr/local/bin/ld: /usr/src/contrib/libpcap/pcap-rdmasniff.c:252: undefined reference to `ibv_modify_qp'
/usr/local/bin/ld: /usr/src/contrib/libpcap/pcap-rdmasniff.c:322: undefined reference to `ibv_dereg_mr'
/usr/local/bin/ld: /usr/src/contrib/libpcap/pcap-rdmasniff.c:330: undefined reference to `ibv_destroy_qp'
/usr/local/bin/ld: /usr/src/contrib/libpcap/pcap-rdmasniff.c:334: undefined reference to `ibv_destroy_cq'
/usr/local/bin/ld: /usr/src/contrib/libpcap/pcap-rdmasniff.c:338: undefined reference to `ibv_destroy_comp_channel'
/usr/local/bin/ld: /usr/src/contrib/libpcap/pcap-rdmasniff.c:342: undefined reference to `ibv_dealloc_pd'
/usr/local/bin/ld: /usr/src/contrib/libpcap/pcap-rdmasniff.c:346: undefined reference to `ibv_close_device'
/usr/local/bin/ld: /usr/src/contrib/libpcap/pcap-rdmasniff.c:284: undefined reference to `ibv_reg_mr'
/usr/local/bin/ld: /usr/lib/libpcap.a(pcap-rdmasniff.o): in function `___ibv_query_port':
/usr/obj/usr/src/amd64.amd64/tmp/usr/include/infiniband/verbs.h:1662: undefined reference to `ibv_query_port'
/usr/local/bin/ld: /usr/lib/libpcap.a(pcap-rdmasniff.o): in function `rdmasniff_findalldevs':
/usr/src/contrib/libpcap/pcap-rdmasniff.c:417: undefined reference to `ibv_get_device_list'
/usr/local/bin/ld: /usr/src/contrib/libpcap/pcap-rdmasniff.c:434: undefined reference to `ibv_free_device_list'
/usr/local/bin/ld: /usr/lib/libpcap.a(pcap-rdmasniff.o): in function `rdmasniff_read':
/usr/src/contrib/libpcap/pcap-rdmasniff.c:148: undefined reference to `ibv_wc_status_str'
/usr/local/bin/ld: /usr/src/contrib/libpcap/pcap-rdmasniff.c:125: undefined reference to `ibv_get_cq_event'
/usr/local/bin/ld: /usr/src/contrib/libpcap/pcap-rdmasniff.c:134: undefined reference to `ibv_ack_cq_events'
/usr/local/bin/ld: /usr/lib/libpcap.a(pcap-rdmasniff.o): in function `rdmasniff_cleanup':
/usr/src/contrib/libpcap/pcap-rdmasniff.c:82: undefined reference to `ibv_dereg_mr'
/usr/local/bin/ld: /usr/src/contrib/libpcap/pcap-rdmasniff.c:84: undefined reference to `ibv_destroy_qp'
/usr/local/bin/ld: /usr/src/contrib/libpcap/pcap-rdmasniff.c:85: undefined reference to `ibv_destroy_cq'
/usr/local/bin/ld: /usr/src/contrib/libpcap/pcap-rdmasniff.c:86: undefined reference to `ibv_dealloc_pd'
/usr/local/bin/ld: /usr/src/contrib/libpcap/pcap-rdmasniff.c:87: undefined reference to `ibv_destroy_comp_channel'
/usr/local/bin/ld: /usr/src/contrib/libpcap/pcap-rdmasniff.c:88: undefined reference to `ibv_close_device'
collect2: error: ld returned 1 exit status
*** Error code 1

Stop.
make: stopped in /root/udp2raw
```